### PR TITLE
Added support for HTML tags and blocks of HTML tags.

### DIFF
--- a/lib/Text/Markdown/to/HTML.pm6
+++ b/lib/Text/Markdown/to/HTML.pm6
@@ -66,6 +66,11 @@ class Text::Markdown::to::HTML {
         }
         '<a href="' ~ $url ~ '">' ~ $r.text ~ '</a>';
     }
+
+    multi method render(Text::Markdown::EmailLink $r) {
+      '< href="mailto:' ~ $r.url ~ '">' ~ $r.url ~ '</a>';
+    }
+
     multi method render(Text::Markdown::Image $r) { 
         my $url = $r.url;
         unless $url {
@@ -81,4 +86,13 @@ class Text::Markdown::to::HTML {
             '<strong>' ~ $r.text ~ '</strong>';
         }
     }
+
+    multi method render(Text::Markdown::HtmlBlock $r) {
+      $r.items.map( -> $child { self.render($child) } ).join("");
+    }
+
+    multi method render(Text::Markdown::HtmlTag $r) {
+      $r.tag;
+    }
 }
+


### PR DESCRIPTION
This commit adds proper support for HTML tags.

When it finds angle brackets, it tries to identify whether the content is an URL or an email address. If neither is true, it assumes that the contents are HTML tags.

Closes #8.