### PR TITLE
Fixes issue with opening fence inclusion in generated HTML

### DIFF
--- a/lib/Text/Markdown/to/HTML.pm6
+++ b/lib/Text/Markdown/to/HTML.pm6
@@ -30,7 +30,8 @@ class Text::Markdown::to::HTML {
     }
 
     multi method render(Text::Markdown::CodeBlock $c) {
-        '<pre><code>' ~ escape-html($c.text) ~ '</code></pre>';
+        my $lang-class = $c.lang ?? ' class="' ~ $c.lang ~ '"' !! '';
+        "<pre><code{$lang-class}>" ~ escape-html($c.text) ~ '</code></pre>';
     }
 
     multi method render(Text::Markdown::List $l) {

--- a/t/parse.t
+++ b/t/parse.t
@@ -2,7 +2,7 @@ use v6;
 use Text::Markdown::Document;
 use Test;
 
-plan 184;
+plan 190;
 
 my $text = q:to/TEXT/;
 ## Markdown Test ##
@@ -100,7 +100,32 @@ ok $li.items == 2, '...with two items';
 
 $li = $document.items[5];
 ok $li ~~ Text::Markdown::List, 'sixth element is a list';
-ok $li.items == 2;
+ok $li.items == 2, '...with two items';
+
+## next text with fenced code blocks
+$text = q:to/TEXT/;
+```
+# unknown
+code
+```
+
+```raku
+# raku code
+```
+
+TEXT
+
+$document = Text::Markdown::Document.new($text);
+ok $document ~~ Text::Markdown::Document, 'Able to parse';
+is $document.items.elems, 2, 'has correct number of items';
+
+$ci = $document.items[0];
+ok $ci ~~ Text::Markdown::CodeBlock, 'first element is a code block';
+is $ci.text, "# unknown\ncode", '...with correct data';
+
+$ci = $document.items[1];
+ok $ci ~~ Text::Markdown::CodeBlock, 'second element is a code block';
+is $ci.text, "# raku code", '...with correct data';
 
 ## next text with lists
 $text = q:to/TEXT/;


### PR DESCRIPTION
Previously when a language was specified in a fenced block code, besides not adding a class attribute to the `<code>` element, the opening fence would be included in the generated HTML.

For instance:

    ```raku
    # raku code
    ```
would render as

```
<pre><code>&#96;&#96;&#96;raku
# raku code</code></pre>
```

Now it renders as

```
<pre><code class="raku"># raku code</code></pre>
```

Fenced block codes without specified language works as before.